### PR TITLE
Add support for retrieving local licenses

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,6 +33,7 @@ type Client interface {
 	DownloadLicenseFromHub(ctx context.Context, authToken, subscriptionID string) (license *model.IssuedLicense, err error)
 	ParseLicense(license []byte) (parsedLicense *model.IssuedLicense, err error)
 	StoreLicense(ctx context.Context, dclnt WrappedDockerClient, licenses *model.IssuedLicense, localRootDir string) error
+	LoadLocalLicense(ctx context.Context, dclnt WrappedDockerClient) (*model.Subscription, error)
 }
 
 func (c *client) LoginViaAuth(ctx context.Context, username, password string) (string, error) {

--- a/model/subscriptions.go
+++ b/model/subscriptions.go
@@ -20,42 +20,41 @@ func (comps PricingComponents) Less(i, j int) bool { return comps[i].Name < comp
 
 // Subscription includes the base fields that will be meaningful to most of the clients consuming this api
 type Subscription struct {
-	Name               string            `json:"name"`
-	ID                 string            `json:"subscription_id"`
-	DockerID           string            `json:"docker_id"`
-	ProductID          string            `json:"product_id"`
-	CreatedByID        string            `json:"created_by_docker_id"`
-	ProductRatePlan    string            `json:"product_rate_plan"`
-	ProductRatePlanID  string            `json:"product_rate_plan_id"`
-	InitialPeriodStart time.Time         `json:"initial_period_start"`
-	CurrentPeriodStart time.Time         `json:"current_period_start"`
-	CurrentPeriodEnd   *time.Time        `json:"current_period_end,omitempty"`
-	State              string            `json:"state"`
-	Eusa               *EusaState        `json:"eusa,omitempty"`
-	PricingComponents  PricingComponents `json:"pricing_components"`
+	Name              string            `json:"name"`
+	ID                string            `json:"subscription_id"`
+	DockerID          string            `json:"docker_id"`
+	ProductID         string            `json:"product_id"`
+	ProductRatePlan   string            `json:"product_rate_plan"`
+	ProductRatePlanID string            `json:"product_rate_plan_id"`
+	Start             *time.Time        `json:"current_period_start,omitempty"`
+	Expires           *time.Time        `json:"current_period_end,omitempty"`
+	State             string            `json:"state"`
+	Eusa              *EusaState        `json:"eusa,omitempty"`
+	PricingComponents PricingComponents `json:"pricing_components"`
 }
 
 func (s *Subscription) String() string {
 	storeURL := "https://store.docker.com"
 
-	var expirationMsg, statusMsg string
+	var nameMsg, expirationMsg, statusMsg string
 	switch s.State {
 	case "cancelled":
-		statusMsg = fmt.Sprintf("Cancelled! You will no longer receive updates. To purchase go to %s", storeURL)
-		expirationMsg = fmt.Sprintf("Expiration date: %s", s.CurrentPeriodEnd.Format("2/1/2006"))
+		statusMsg = fmt.Sprintf("\tCancelled! You will no longer receive updates. To purchase go to %s", storeURL)
+		expirationMsg = fmt.Sprintf("Expiration date: %s", s.Expires.Format("2006-01-02"))
 	case "expired":
-		statusMsg = fmt.Sprintf("Expired! You will no longer receive updates. Please renew at %s", storeURL)
-		expirationMsg = fmt.Sprintf("Expiration date: %s", s.CurrentPeriodEnd.Format("2/1/2006"))
+		statusMsg = fmt.Sprintf("\tExpired! You will no longer receive updates. Please renew at %s", storeURL)
+		expirationMsg = fmt.Sprintf("Expiration date: %s", s.Expires.Format("2006-01-02"))
 	case "preparing":
-		statusMsg = "Your subscription has not yet begun"
-		expirationMsg = fmt.Sprintf("Activation date: %s", s.CurrentPeriodStart.Format("2/1/2006"))
+		statusMsg = "\tYour subscription has not yet begun"
+		expirationMsg = fmt.Sprintf("Activation date: %s", s.Start.Format("2006-01-02"))
 	case "failed":
-		statusMsg = "Oops, this subscription did not get setup properly!"
+		statusMsg = "\tOops, this subscription did not get setup properly!"
 		expirationMsg = ""
 	case "active":
-		statusMsg = "License is currently active"
-		expirationMsg = fmt.Sprintf("Expiration date: %s", s.CurrentPeriodEnd.Format("2/1/2006"))
+		statusMsg = "\tLicense is currently active"
+		expirationMsg = fmt.Sprintf("Expiration date: %s", s.Expires.Format("2006-01-02"))
 	default:
+		expirationMsg = fmt.Sprintf("Expiration date: %s", s.Expires.Format("2006-01-02"))
 	}
 
 	pcStrs := make([]string, len(s.PricingComponents))
@@ -63,17 +62,25 @@ func (s *Subscription) String() string {
 		pcStrs[i] = fmt.Sprintf("%d %s", pc.Value, pc.Name)
 	}
 	quantityMsg := "Quantity: " + strings.Join(pcStrs, ", ")
-	nameMsg := fmt.Sprintf("License Name: %s", s.Name)
+	if s.Name != "" {
+		nameMsg = fmt.Sprintf("License Name: %s\t", s.Name)
+	} else if s.ProductRatePlan == "free-trial" {
+		// TODO - consider a humanized formatting for expiration time on trials (e.g., "10 days remaining")
+		nameMsg = "Free trial\t"
+		statusMsg = fmt.Sprintf("\tTo purchase go to %s", storeURL)
+	}
 
-	return fmt.Sprintf("%s\t%s\t%s - %s", nameMsg, quantityMsg, expirationMsg, statusMsg)
+	return fmt.Sprintf("%s%s\t%s%s", nameMsg, quantityMsg, expirationMsg, statusMsg)
 }
 
 // SubscriptionDetail presents Subscription information to billing service clients.
 type SubscriptionDetail struct {
 	Subscription
-	Origin      string `json:"origin,omitempty"`
-	OrderID     string `json:"order_id,omitempty"`
-	OrderItemID string `json:"order_item_id,omitempty"`
+	Origin             string    `json:"origin,omitempty"`
+	OrderID            string    `json:"order_id,omitempty"`
+	OrderItemID        string    `json:"order_item_id,omitempty"`
+	InitialPeriodStart time.Time `json:"initial_period_start"`
+	CreatedByID        string    `json:"created_by_docker_id"`
 
 	// If true, the product for this subscription uses product keys. To
 	// obtain the keys, the frontend or billing client will need to


### PR DESCRIPTION
This adds support to the licensing client to retrieve
a stored local license.  Existing legacy licenses
are adapted to the new Subscription format for easier
consumption by clients.

Signed-off-by: Daniel Hiltgen <daniel.hiltgen@docker.com>