### PR TITLE
update client to match new license model

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ func main() {
 	// find first available subscription with given feature
 	var featuredSub *model.Subscription
 	for _, sub := range subs {
-		_, ok := sub.CheckFeature(appFeature)
+		_, ok := sub.GetFeatureValue(appFeature)
 		if ok {
 			featuredSub = sub
 			break

--- a/README.md
+++ b/README.md
@@ -3,10 +3,88 @@ docker/licensing
 
 ## Overview
 
-*licensing* is a library for interacting with Docker issued product licenses. It facilitates user's authentication to the [Docker Store](https://store.docker.com), provides a mechanism for retrieving a user's existing licenses, detects and verifies locally stored licenses, and can be used to provision trial licenses for [Docker Enterprise Edition](https://www.docker.com/enterprise-edition).
+*licensing* is a library for interacting with Docker issued product licenses. It facilitates user's authentication to the [Docker Hub](https://hub.docker.com), provides a mechanism for retrieving a user's existing docker-issued subscriptions/licenses, detects and verifies locally stored licenses, and can be used to provision trial licenses for [Docker Enterprise Edition](https://www.docker.com/enterprise-edition).
 
 License
 =========
 docker/licensing is licensed under the Apache License, Version 2.0. See
 [LICENSE](https://github.com/docker/licensing/blob/master/LICENSE) for the full
 license text.
+
+Usage
+========
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/docker/licensing"
+	"github.com/docker/licensing/model"
+)
+
+const (
+	hubURL      = "https://hub.docker.com"
+	pubKey      = "LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0Ka2lkOiBKN0xEOjY3VlI6TDVIWjpVN0JBOjJPNEc6NEFMMzpPRjJOOkpIR0I6RUZUSDo1Q1ZROk1GRU86QUVJVAoKTUlJQ0lqQU5CZ2txaGtpRzl3MEJBUUVGQUFPQ0FnOEFNSUlDQ2dLQ0FnRUF5ZEl5K2xVN283UGNlWSs0K3MrQwpRNU9FZ0N5RjhDeEljUUlXdUs4NHBJaVpjaVk2NzMweUNZbndMU0tUbHcrVTZVQy9RUmVXUmlvTU5ORTVEczVUCllFWGJHRzZvbG0ycWRXYkJ3Y0NnKzJVVUgvT2NCOVd1UDZnUlBIcE1GTXN4RHpXd3ZheThKVXVIZ1lVTFVwbTEKSXYrbXE3bHA1blEvUnhyVDBLWlJBUVRZTEVNRWZHd20zaE1PL2dlTFBTK2hnS1B0SUhsa2c2L1djb3hUR29LUAo3OWQvd2FIWXhHTmw3V2hTbmVpQlN4YnBiUUFLazIxbGc3OThYYjd2WnlFQVRETXJSUjlNZUU2QWRqNUhKcFkzCkNveVJBUENtYUtHUkNLNHVvWlNvSXUwaEZWbEtVUHliYncwMDBHTyt3YTJLTjhVd2dJSW0waTVJMXVXOUdrcTQKempCeTV6aGdxdVVYYkc5YldQQU9ZcnE1UWE4MUR4R2NCbEp5SFlBcCtERFBFOVRHZzR6WW1YakpueFpxSEVkdQpHcWRldlo4WE1JMHVrZmtHSUkxNHdVT2lNSUlJclhsRWNCZi80Nkk4Z1FXRHp4eWNaZS9KR1grTEF1YXlYcnlyClVGZWhWTlVkWlVsOXdYTmFKQitrYUNxejVRd2FSOTNzR3crUVNmdEQwTnZMZTdDeU9IK0U2dmc2U3QvTmVUdmcKdjhZbmhDaVhJbFo4SE9mSXdOZTd0RUYvVWN6NU9iUHlrbTN0eWxyTlVqdDBWeUFtdHRhY1ZJMmlHaWhjVVBybQprNGxWSVo3VkQvTFNXK2k3eW9TdXJ0cHNQWGNlMnBLRElvMzBsSkdoTy8zS1VtbDJTVVpDcXpKMXlFbUtweXNICjVIRFc5Y3NJRkNBM2RlQWpmWlV2TjdVQ0F3RUFBUT09Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo="
+	username    = "docker username"
+	password    = "your password"
+	appFeature  = "jump"
+)
+
+func panicOnErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	hubURI, err := url.Parse(hubURL)
+	panicOnErr(err)
+
+	// setup client
+	c, err := licensing.New(&licensing.Config{
+		BaseURI:    *hubURI,
+		HTTPClient: nil,
+		PublicKeys: []string{pubKey},
+	})
+	panicOnErr(err)
+
+	// grab token
+	ctx := context.Background()
+	token, err := c.LoginViaAuth(ctx, username, password)
+	panicOnErr(err)
+
+	// fetch dockerID, if not already known
+	id, err := c.GetHubUserByName(ctx, username)
+	panicOnErr(err)
+
+	subs, err := c.ListSubscriptions(ctx, token, id.ID)
+	panicOnErr(err)
+
+	// find first available subscription with given feature
+	var featuredSub *model.Subscription
+	for _, sub := range subs {
+		_, ok := sub.CheckFeature(appFeature)
+		if ok {
+			featuredSub = sub
+			break
+		}
+	}
+	if featuredSub == nil {
+		fmt.Println("account has no subscriptions with the desired feature entitlements")
+		return
+	}
+
+	// download license file for this subscription
+	subLic, err := c.DownloadLicenseFromHub(ctx, token, featuredSub.ID)
+	panicOnErr(err)
+
+	// verify license is issued by corresponding keypair and is not expired
+	licFile, err := c.VerifyLicense(ctx, *subLic)
+	panicOnErr(err)
+
+	fmt.Println("license summary: ", c.SummarizeLicense(licFile))
+}
+```

--- a/client.go
+++ b/client.go
@@ -35,7 +35,7 @@ type Client interface {
 	ParseLicense(license []byte) (parsedLicense *model.IssuedLicense, err error)
 	StoreLicense(ctx context.Context, dclnt WrappedDockerClient, licenses *model.IssuedLicense, localRootDir string) error
 	LoadLocalLicense(ctx context.Context, dclnt WrappedDockerClient) (*model.Subscription, error)
-	SummarizeLicense(res *model.CheckResponse, keyID string) *model.Subscription
+	SummarizeLicense(res *model.CheckResponse) *model.Subscription
 }
 
 func (c *client) LoginViaAuth(ctx context.Context, username, password string) (string, error) {
@@ -115,7 +115,7 @@ func (c *client) ListSubscriptions(ctx context.Context, authToken, dockerID stri
 	// filter out non docker licenses
 	dockerSubs := []*model.Subscription{}
 	for _, sub := range subs {
-		if !strings.HasPrefix(sub.ProductID, "docker-ee") {
+		if !strings.HasPrefix(sub.ProductID, "docker") {
 			continue
 		}
 
@@ -139,7 +139,7 @@ func (c *client) ListSubscriptionsDetails(ctx context.Context, authToken, docker
 	// filter out non docker licenses
 	dockerSubs := []*model.SubscriptionDetail{}
 	for _, sub := range subs {
-		if !strings.HasPrefix(sub.ProductID, "docker-ee") {
+		if !strings.HasPrefix(sub.ProductID, "docker") {
 			continue
 		}
 

--- a/model/license.go
+++ b/model/license.go
@@ -11,6 +11,21 @@ type CheckResponse struct {
 	ScanningEnabled bool      `json:"scanningEnabled"`
 	Type            string    `json:"licenseType"`
 	Tier            string    `json:"tier"`
+
+	SubscriptionID    string            `json:"subscription_id,omitempty"`
+	ProductID         string            `json:"product_id,omitempty"`
+	RatePlanID        string            `json:"rate_plan_id,omitempty"`
+	Version           int               `json:"version"`
+	GraceDays         int               `json:"grace_days,omitempty"`
+	Metadata          *Metadata         `json:"metadata,omitempty"`
+	PricingComponents PricingComponents `json:"pricing_components,omitempty"`
+}
+
+// Metadata holds non-essential license information, that is, anything that is not required by clients to ensure
+// the license is valid
+type Metadata struct {
+	Username string `json:"username,omitempty"`
+	Company  string `json:"company,omitempty"`
 }
 
 // IssuedLicense represents an issued license

--- a/model/subscriptions.go
+++ b/model/subscriptions.go
@@ -34,9 +34,9 @@ type Subscription struct {
 	GraceDays         int               `json:"grace_days"`
 }
 
-// CheckFeature returns true if a given feature is among a subscription's pricing component entitlements along with
+// GetFeatureValue returns true if a given feature is among a subscription's pricing component entitlements along with
 // it's corresponding value and false if it is not found
-func (s *Subscription) CheckFeature(featureName string) (int, bool) {
+func (s *Subscription) GetFeatureValue(featureName string) (int, bool) {
 	for _, component := range s.PricingComponents {
 		if component.Name == featureName && component.Value > 0 {
 			return component.Value, true

--- a/model/subscriptions.go
+++ b/model/subscriptions.go
@@ -31,6 +31,19 @@ type Subscription struct {
 	State             string            `json:"state"`
 	Eusa              *EusaState        `json:"eusa,omitempty"`
 	PricingComponents PricingComponents `json:"pricing_components"`
+	GraceDays         int               `json:"grace_days"`
+}
+
+// CheckFeature returns true if a given feature is among a subscription's pricing component entitlements along with
+// it's corresponding value and false if it is not found
+func (s *Subscription) CheckFeature(featureName string) (int, bool) {
+	for _, component := range s.PricingComponents {
+		if component.Name == featureName && component.Value > 0 {
+			return component.Value, true
+		}
+	}
+
+	return 0, false
 }
 
 func (s *Subscription) String() string {
@@ -61,7 +74,7 @@ func (s *Subscription) String() string {
 	for i, pc := range s.PricingComponents {
 		pcStrs[i] = fmt.Sprintf("%d %s", pc.Value, pc.Name)
 	}
-	quantityMsg := "Quantity: " + strings.Join(pcStrs, ", ")
+	componentsMsg := "Components: " + strings.Join(pcStrs, ", ")
 	if s.Name != "" {
 		nameMsg = fmt.Sprintf("License Name: %s\t", s.Name)
 	} else if s.ProductRatePlan == "free-trial" {
@@ -70,7 +83,7 @@ func (s *Subscription) String() string {
 		statusMsg = fmt.Sprintf("\tTo purchase go to %s", storeURL)
 	}
 
-	return fmt.Sprintf("%s%s\t%s%s", nameMsg, quantityMsg, expirationMsg, statusMsg)
+	return fmt.Sprintf("%s%s\t%s%s", nameMsg, componentsMsg, expirationMsg, statusMsg)
 }
 
 // SubscriptionDetail presents Subscription information to billing service clients.

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -42,6 +42,7 @@ func (c *client) listSubscriptions(ctx context.Context, params map[string]string
 	values.Set("docker_id", params["docker_id"])
 	values.Set("partner_account_id", params["partner_account_id"])
 	values.Set("origin", params["origin"])
+	values.Set("include_orgs", "true")
 
 	url := c.baseURI
 	url.Path += "/api/billing/v4/subscriptions"


### PR DESCRIPTION
This commit adopts the new license model served by hub as of April 5th,
2019. It adds a CheckFeature method to aid clients in feature entitlement
checks, and includes an updated readme with usage examples.

Signed-off-by: Mason Fish <mason.fish@docker.com>