### PR TITLE
Fix TestPanic1 for Go 1.12 and up

### DIFF
--- a/lib/errors/error_test.go
+++ b/lib/errors/error_test.go
@@ -188,7 +188,8 @@ func TestPanic1(t *testing.T) {
 	stack, wraps, cause := Cause(err)
 
 	require.NotNil(t, stack)
-	require.Len(t, stack, 9)
+	// go 1.12 produces 8, go 1.11 and under produces 9
+	require.True(t, len(stack) >= 8)
 	require.NotNil(t, wraps)
 	require.Regexp(t, "panicBottom1", cause.Error())
 	require.Len(t, wraps, 1)


### PR DESCRIPTION
This was failing on Go 1.12

```
--- FAIL: TestPanic1 (0.00s)
        Error Trace:    error_test.go:191
        Error:		"[/Users/sebastiaan/go/src/github.com/docker/licensing/lib/errors/panic1_test.go:14 /usr/local/Cellar/go/1.12.5/libexec/src/runtime/panic.go:522 /Users/sebastiaan/go/src/github.com/docker/licensing/lib/errors/panic1_test.go:24 /Users/sebastiaan/go/src/github.com/docker/licensing/lib/errors/panic1_test.go:20 /Users/sebastiaan/go/src/github.com/docker/licensing/lib/errors/panic1_test.go:16 /Users/sebastiaan/go/src/github.com/docker/licensing/lib/errors/error_test.go:185 /usr/local/Cellar/go/1.12.5/libexec/src/testing/testing.go:865 /usr/local/Cellar/go/1.12.5/libexec/src/runtime/asm_amd64.s:1337]" should have 9 item(s), but has 8
```