### PR TITLE
ParseLicense: fix incorrectly stripping BOM

### DIFF
--- a/client.go
+++ b/client.go
@@ -166,7 +166,7 @@ func (c *client) ParseLicense(license []byte) (*model.IssuedLicense, error) {
 	parsedLicense := &model.IssuedLicense{}
 	// The file may contain a leading BOM, which will choke the
 	// json deserializer.
-	license = bytes.Trim(license, "\xef\xbb\xbf")
+	license = bytes.TrimPrefix(license, []byte("\xef\xbb\xbf"))
 
 	if err := json.Unmarshal(license, &parsedLicense); err != nil {
 		return nil, errors.WithMessage(err, "failed to parse license")


### PR DESCRIPTION
`bytes.Trim()` takes a cutset as argument, which means that any character occurring in the cutset will be removed from the start (and end) of the input.

For example (replacing the BOM characters with readable characters):

```go
license := []byte("BOMMOBhelloBOMMOB")
parsed := bytes.Trim(license, "BOM")
fmt.Println(string(parsed))
```

Will produce:

```
hello
```

This patch updates the function to use `bytes.TrimPrefix()` which takes a `prefix` as argument, and only removes exact occurences of the given prefix:

```go
license := []byte("BOMMOBhelloBOMMOB")
parsed = bytes.TrimPrefix(license, []byte("BOM"))
fmt.Println(string(parsed))
```

Will produce:

```
MOBhelloBOMMOB
```

Also see https://play.golang.org/p/H_cFZ80miNV for an example